### PR TITLE
Close faulthandler file properly.

### DIFF
--- a/pytest_faulthandler.py
+++ b/pytest_faulthandler.py
@@ -13,10 +13,12 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     if config.getoption('fault_handler'):
         stderr_fd_copy = os.dup(sys.stderr.fileno())
-        stderr_copy = os.fdopen(stderr_fd_copy, 'w')
-        faulthandler.enable(stderr_copy)
+        config.fault_handler_stderr = os.fdopen(stderr_fd_copy, 'w')
+        faulthandler.enable(config.fault_handler_stderr)
 
 
 def pytest_unconfigure(config):
     if config.getoption('fault_handler'):
         faulthandler.disable()
+        config.fault_handler_stderr.close()
+        del config.fault_handler_stderr


### PR DESCRIPTION
Without this, I get this `ResourceWarning` when using pytest-faulthandler with all warnings enabled:

```
.../pytest_faulthandler.py:22: ResourceWarning: unclosed file <_io.TextIOWrapper name=9 mode='w' encoding='UTF-8'>
  faulthandler.disable()
```

I also tried adding a test for this, but I couldn't get it to work right - the `ResourceWarning` was suddenly gone when using `warnings.catch_warnings(record=True) as w: ...`.

There might be a cleaner version to save the file object with pytest instead of creating a global - please let me know if there is!

This also assumes `pytest_unconfigure` gets never called without `pytest_configure` being called (otherwise there'd be a `NameError`). But I think this assumption is true.
