### PR TITLE
Revert "Adding setup.cfg to configure bdist_wheel for universal mode"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[bdist_wheel]
-universal = 1
-


### PR DESCRIPTION
This reverts commit f371ef70e10cbecd941333c4b88c19c8c2cdb290.

The wheel for pytest-faulthandler is not universal, as it conditionally depends on faulthandler based on the Python version in setup.py.

I get this when trying to install 0.2 via pip:

```
$ [pip install pytest-faulthandler==0.2
Collecting pytest-faulthandler==0.2
  Downloading pytest_faulthandler-0.2-py2.py3-none-any.whl
Collecting faulthandler (from pytest-faulthandler==0.2)
  Downloading faulthandler-2.4.tar.gz
    ERROR: faulthandler is a builtin module since Python 3.3
    Complete output from command python setup.py egg_info:
    ERROR: faulthandler is a builtin module since Python 3.3

    ----------------------------------------
    Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-7hvucfvx/faulthandler
```
