### PR TITLE
--faulthandler-timeout now shows a warning instead of an error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,36 @@
+1.1.0
+-----
+
+* ``--faulthandler-timeout`` option is now properly supported in Python 3+; 
+  also a warning is issued instead of an error on platforms without a 
+  ``faulthandler.dump_traceback_later`` function (`#8`_).
+   
+   
+.. _#8: https://github.com/pytest-dev/pytest-faulthandler/issues/8   
+
+
+1.0.1
+-----
+
+Release to ensure Python 3.5 compatibility and to provide wheels on PyPI again.
+
+
+1.0
+----
+
+First 1.0 release.
+
+0.2
+----
+
+Now properly closing the stream used by the fault handler, thanks to complete 
+PR by `@The-Compiler`_. Many thanks!
+
+
+0.1
+----
+
+First public release
+
+
+.. _@The-Compiler: https://github.com/The-Compiler

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,6 @@ Options:
 
 * ``--faulthandler-timeout=TIMEOUT``: Dump the traceback of all threads if a
   test takes more than TIMEOUT seconds to finish.
-  Not available on Windows.
 
 
 Requirements
@@ -56,6 +55,6 @@ Install using `pip <http://pip-installer.org/>`_:
 Change Log
 ==========
 
-Please consult the `releases page`_.
+Please consult the `CHANGELOG`_.
 
-.. _releases page: https://github.com/pytest-dev/pytest-faulthandler/releases     
+.. _CHANGELOG: https://github.com/pytest-dev/pytest-faulthandler/blob/master/CHANGELOG.rst


### PR DESCRIPTION
On platforms or python versions that don't support it (I just realized that Python 3 on Windows supports the `dump_traceback_later` and `cancel_dump_traceback_later` functions).

Fixes #8 
