### PR TITLE
Cancel traceback dumping on pytest_exception_interact

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+1.3.0
+-----
+
+* Now traceback dumping due to an interactive exception is raised (`#14`_).
+  Thanks to `@flub`_ for the request.
+
+.. _#14: https://github.com/pytest-dev/pytest-faulthandler/issues/14
+
+
 1.2.0
 -----
 
@@ -42,3 +51,4 @@ First public release
 
 
 .. _@The-Compiler: https://github.com/The-Compiler
+.. _@flub: https://github.com/flub

--- a/pytest_faulthandler.py
+++ b/pytest_faulthandler.py
@@ -58,9 +58,24 @@ def pytest_runtest_protocol(item):
         yield
 
 
-def pytest_enter_pdb():
-    """Cancel any traceback dumping due to timeout before entering pdb.
+def _cancel_traceback_dump():
+    """Cancel traceback dumping if timeout support is available.
     """
     if timeout_support_available():
         import faulthandler
         faulthandler.cancel_dump_traceback_later()
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_enter_pdb():
+    """Cancel any traceback dumping due to timeout before entering pdb.
+    """
+    _cancel_traceback_dump()
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_exception_interact():
+    """Cancel any traceback dumping due to an interactive exception being
+    raised.
+    """
+    _cancel_traceback_dump()


### PR DESCRIPTION
Fix #14
