### PR TITLE
PyPy: Support installation with pip and run tests on travis-ci. Fixes #28

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
   - 3.5
   - 3.6
   - nightly
+  - pypy2.7-5.10.0
+  - pypy3.5-5.10.1
 install:
   - pip install tox-travis
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,4 +4,4 @@ install:
 build: false  # Not a C# project
 
 test_script:
-  - C:\Python36\scripts\tox
+  - C:\Python36\scripts\tox --skip-missing-interpreters

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     description='py.test plugin that activates the fault handler module for tests',
     long_description=long_description,
     extras_require={
-        ':python_version=="2.7"': ['faulthandler'],
+        ':python_version=="2.7" and platform_python_implementation != "PyPy"': ['faulthandler'],
     },
     entry_points={
         'pytest11': ['pytest_faulthandler = pytest_faulthandler'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36}
+envlist = py{27,34,35,36},pypy,pypy3
 
 [testenv]
 commands = py.test test_pytest_faulthandler.py


### PR DESCRIPTION
pypy2 includes a faulthandler compatible module and doesn't work with the C
extension from pypi. This makes it not require the package when installing with PyPy.

While at it add some travis-ci jobs for PyPy.